### PR TITLE
Fixed misleading Readme file.

### DIFF
--- a/README
+++ b/README
@@ -5,10 +5,9 @@ Written by Jesper Eskilson (jesper@eskilson.se)
 Requirements
 ------------
 
-* CMake version 2.6 
+* CMake version 2.6+
 
-* Protocol Buffers version 2.2.x. Version 2.3.0 is not supported in
-this version of protobuf-cmake.
+* Protocol Buffers version 2.4.x.
 
 Instructions
 ------------


### PR DESCRIPTION
The Readme file (that is the front page presentation of this repository) says these scripts don't work with Protobuf 2.3 and higher versions. 
Recent comits shows that this is false, so this file needs update.
