### PR TITLE
updated to support protobuf v2.6.1

### DIFF
--- a/libprotobuf/CMakeLists.txt
+++ b/libprotobuf/CMakeLists.txt
@@ -38,6 +38,9 @@ append_if_exist(SOURCES
   ${PROTOBUF_ROOT}/src/google/protobuf/wire_format.cc
   ${PROTOBUF_ROOT}/src/google/protobuf/wire_format_lite.cc
 #  ${PROTOBUF_ROOT}/src/google/protobuf/stubs/hash.cc
+
+# v2.6.1
+  ${PROTOBUF_ROOT}/src/google/protobuf/io/strtod.cc
 )
 
 if(WIN32 AND BUILD_SHARED_LIBS AND MSVC)
@@ -90,6 +93,7 @@ append_if_exist(INSTALL_FILES_LIST
     ${PROTOBUF_ROOT}/src/google/protobuf/io/zero_copy_stream.h
     ${PROTOBUF_ROOT}/src/google/protobuf/io/zero_copy_stream_impl.h
     ${PROTOBUF_ROOT}/src/google/protobuf/io/zero_copy_stream_impl_lite.h
+    ${PROTOBUF_ROOT}/src/google/protobuf/io/strtod.h
     ${PROTOBUF_ROOT}/src/google/protobuf/message.h
     ${PROTOBUF_ROOT}/src/google/protobuf/message_lite.h
     ${PROTOBUF_ROOT}/src/google/protobuf/reflection_ops.h

--- a/libprotoc/CMakeLists.txt
+++ b/libprotoc/CMakeLists.txt
@@ -37,6 +37,13 @@ append_if_exist(SOURCES
   ${PROTOBUF_ROOT}/src/google/protobuf/compiler/subprocess.cc
   ${PROTOBUF_ROOT}/src/google/protobuf/compiler/java/java_string_field.cc
   ${PROTOBUF_ROOT}/src/google/protobuf/compiler/java/java_doc_comment.cc
+
+  # new as of 2.6.x
+  ${PROTOBUF_ROOT}/src/google/protobuf/compiler/java/java_context.cc
+  ${PROTOBUF_ROOT}/src/google/protobuf/compiler/java/java_generator_factory.cc
+  ${PROTOBUF_ROOT}/src/google/protobuf/compiler/java/java_lazy_message_field.cc
+  ${PROTOBUF_ROOT}/src/google/protobuf/compiler/java/java_name_resolver.cc
+  ${PROTOBUF_ROOT}/src/google/protobuf/compiler/java/java_shared_code_generator.cc
   )
 
 if(WIN32 AND BUILD_SHARED_LIBS AND MSVC)


### PR DESCRIPTION
Hello, 
I've updated CMakeLists.txt to support latest protobuf version (v2.6.1).
Could you please review and merge?
Thank you.
