### PR TITLE
add windows MSVC support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ project(Protobuf)
 cmake_minimum_required(VERSION 2.6)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
+set(protobuf_DEBUG_POSTFIX "d"
+  CACHE STRING "Default debug postfix")
 include(CheckIncludeFiles)
 include(CheckCxxHashset)
 include(CheckCxxHashmap)
@@ -115,6 +117,15 @@ if(NOT PROTOBUF_ROOT)
 else()
   message(STATUS "Protobuf sources in ${PROTOBUF_ROOT}")
 endif()
+
+if (MSVC)
+  # Add the "lib" prefix for generated .lib outputs.
+  set(LIB_PREFIX lib)
+else (MSVC)
+  # When building with "make", "lib" prefix will be added automatically by
+  # the build tool.
+  set(LIB_PREFIX)
+endif (MSVC)
 
 add_subdirectory(libprotobuf)
 add_subdirectory(libprotoc)

--- a/README
+++ b/README
@@ -26,3 +26,25 @@ this can be set like this:
 
 If you specify -DDOWNLOAD_PROTOBUF=1, the script will automatically
 download protobuf.
+
+For windows users with Visual Studio, an example build script can be like this:
+```bat
+::put this "build-vs2013.bat" file under root folder of this repo
+@echo off
+set build_dir=build-vs2013
+if not exist %build_dir% md %build_dir%
+cd %build_dir%
+cmake .. ^
+    -G "Visual Studio 12 2013" ^
+    -DCMAKE_INSTALL_PREFIX=%cd%/install ^
+    -DPROTOBUF_ROOT=D:/lib/protobuf-2.6.1 ^
+    -DCMAKE_BUILD_TYPE=Debug
+
+cmake --build . --config Debug
+cmake --build . --target install --config Debug
+
+cmake --build . --config Release
+cmake --build . --target install --config Release
+
+cd ..
+```

--- a/libprotobuf/CMakeLists.txt
+++ b/libprotobuf/CMakeLists.txt
@@ -48,7 +48,9 @@ if(WIN32 AND BUILD_SHARED_LIBS AND MSVC)
 endif()
 
 add_library( libprotobuf ${SOURCES} )
-set_target_properties(libprotobuf PROPERTIES OUTPUT_NAME "protobuf")
+set_target_properties(libprotobuf
+    PROPERTIES OUTPUT_NAME "${LIB_PREFIX}protobuf"
+    DEBUG_POSTFIX "${protobuf_DEBUG_POSTFIX}")
 
 if(WIN32 AND BUILD_SHARED_LIBS AND MSVC)
     # Install a spare copy of the dlls to the bin directory for use by protoc.exe

--- a/libprotoc/CMakeLists.txt
+++ b/libprotoc/CMakeLists.txt
@@ -52,10 +52,12 @@ endif()
 
 add_library( libprotoc ${SOURCES} )
 target_link_libraries( libprotoc libprotobuf )
-set_target_properties(libprotoc PROPERTIES OUTPUT_NAME "protoc")
+set_target_properties(libprotoc
+    PROPERTIES OUTPUT_NAME "${LIB_PREFIX}protoc"
+    DEBUG_POSTFIX "${protobuf_DEBUG_POSTFIX}")
 
 if(WIN32 AND BUILD_SHARED_LIBS AND MSVC)
-    # Install 
+    # Install
     install(TARGETS libprotoc
         DESTINATION ${BIN_DIR}
       )


### PR DESCRIPTION
Hi, @jesperes 
I've add prefix and postfix for generated library files on MSVC (e.g. Visual Studio 2013) platform.
Previously, the generated lib files are:
```
protobuf.lib
protoc.lib
```
where no difference between Debug and Release mode.

Now, the generated lib files are:
```
libprotobufd.lib
libprotobuf.lib
libprotocd.lib
libprotoc.lib
```